### PR TITLE
Fix input-triggered button selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.2] - 2026-08-25
+
+### Added
+
+- **`InputActionButtonBase.selectButtonOnInputAction`** (default: `true`) controls whether an input action selects the button after triggering it.
+
+### Fixed
+
+- **`InputActionButtonBase`** input-triggered clicks now update EventSystem selection, so the previously selected button receives its deselect event and no longer keeps selected visuals.
+
 ## [4.1.1] - 2026-07-03
 
 ### Added

--- a/Runtime/Input/InputSystem/Components/Base/InputActionButtonBase.cs
+++ b/Runtime/Input/InputSystem/Components/Base/InputActionButtonBase.cs
@@ -26,6 +26,10 @@ namespace Sentinal.InputSystem.Components
         protected bool sendPointerEvents = true;
 
         [SerializeField]
+        [Tooltip("Selects this button in the EventSystem when its input action triggers it.")]
+        protected bool selectButtonOnInputAction = true;
+
+        [SerializeField]
         [Tooltip(
             "Defers click execution to the next frame to prevent input events carrying over to newly activated views."
         )]
@@ -144,11 +148,8 @@ namespace Sentinal.InputSystem.Components
 
             if (sendPointerEvents && eventSystem != null)
             {
-                ExecuteEvents.Execute(
-                    button.gameObject,
-                    new PointerEventData(eventSystem),
-                    ExecuteEvents.selectHandler
-                );
+                if (selectButtonOnInputAction)
+                    eventSystem.SetSelectedGameObject(button.gameObject);
 
                 // ExecuteEvents.pointerClickHandler will trigger Button's onClick automatically
                 ExecuteEvents.Execute(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.tirt.sentinal",
-    "version": "4.1.1",
+    "version": "4.1.2",
     "displayName": "Sentinal",
     "description": "A package that provides a set of tools to manage menu/view navigation and auto-selection in Unity.",
     "unity": "2021.3",


### PR DESCRIPTION
InputActionButtonBase can now optionally select itself when its input action triggers, defaulting to true for backwards-compatible behavior. The selection is set through EventSystem.SetSelectedGameObject so the previously selected button receives its deselect event and no longer keeps stale selected visuals.